### PR TITLE
Fixed a grammar issue in the name of the panel

### DIFF
--- a/files/application/Espo/Modules/StreamPro/Resources/metadata/app/adminPanel.json
+++ b/files/application/Espo/Modules/StreamPro/Resources/metadata/app/adminPanel.json
@@ -1,6 +1,6 @@
 {
     "extSettings": {
-        "label": "Extensions Settings",
+        "label": "Extension Settings",
         "itemList": [
             "__APPEND__",
             {


### PR DESCRIPTION
The name of the panel should be `Extension` instead of `Extensions` because it is a group noun. With that said, I think it might make more sense for the panel to be named `Kharg's Extensions` or something similar. I have many other extensions that create panels, which may confuse the end user when they see a panel called `Extension Settings` that does not have settings for all extensions. The current name makes it seem like all extensions will have settings in one area.